### PR TITLE
update .eachInside to .walk in order to address deprecation notice

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = postcss.plugin('postcss-shopify-settings-variables',
     return function (css) {
 
         // Transform CSS AST here
-        css.eachInside(function (node) {
+        css.walk(function (node) {
             if ( node.type === 'decl' ) {
                 if ( node.value.indexOf('$(') >= 0 ) {
                     node.value = node.value


### PR DESCRIPTION
update .eachInside to .walk in order to squelch the depreciation notice that comes up every time you use the plugin.
